### PR TITLE
Fix for new_relic paths

### DIFF
--- a/lib/apress/api/api_controller/base.rb
+++ b/lib/apress/api/api_controller/base.rb
@@ -39,12 +39,16 @@ module Apress
 
         # :nocov:
         if defined?(::NewRelic)
-          require "new_relic/agent/instrumentation/rails#{Rails::VERSION::MAJOR}/action_controller"
-
           include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
 
           if Rails::VERSION::MAJOR == 3
+            require "new_relic/agent/instrumentation/rails3/action_controller"
+
             include ::NewRelic::Agent::Instrumentation::Rails3::ActionController
+          else
+            require "new_relic/agent/instrumentation/rails/action_controller"
+
+            include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
           end
         end
         # :nocov:


### PR DESCRIPTION
It also works with older Rails versions

```ruby
pry(main)> require "new_relic/agent/instrumentation/rails/action_controller"
=> true
```
